### PR TITLE
Implement interactive category filter

### DIFF
--- a/src/components/CategoryFilter.tsx
+++ b/src/components/CategoryFilter.tsx
@@ -19,10 +19,45 @@ export default function CategoryFilter({ categories }: CategoryFilterProps) {
     } else {
       params.set('category', category)
     }
-    router.replace(`/?${params.toString()}`, { scroll: false })
+    const queryString = params.toString()
+    router.replace(queryString ? `/?${queryString}` : '/', { scroll: false })
   }
 
-  const allCategories = ['all', ...categories]
+  const uniqueCategories = Array.from(new Set(categories))
+  const allCategories = ['all', ...uniqueCategories]
 
-  return null
+  const renderCategoryButton = (category: string) => {
+    const isActive = activeCategory === category
+
+    return (
+      <motion.button
+        key={category}
+        type="button"
+        onClick={() => handleCategoryChange(category)}
+        className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-400 ${
+          isActive
+            ? 'bg-slate-900 text-white shadow-lg shadow-slate-900/10'
+            : 'bg-white text-slate-600 hover:text-slate-900 hover:bg-slate-100'
+        }`}
+        aria-pressed={isActive}
+        whileHover={{ scale: 1.03 }}
+        whileTap={{ scale: 0.97 }}
+      >
+        {category.replace(/-/g, ' ')}
+      </motion.button>
+    )
+  }
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+      <div className="mx-auto max-w-6xl">
+        <div
+          className="flex w-full items-center gap-3 overflow-x-auto rounded-2xl border border-slate-200 bg-white/60 p-3 backdrop-blur supports-[backdrop-filter]:bg-white/70"
+          data-animate
+        >
+          {allCategories.map(renderCategoryButton)}
+        </div>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- render the category filter UI with animated buttons so users can change the visible project category
- deduplicate categories and normalize router updates when clearing the filter to avoid stray query strings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5dc933b848322a3456e4712edb644